### PR TITLE
fix: pin GitHub Actions to commit SHAs (INT-326)

### DIFF
--- a/.github/workflows/feature-branch-chatops.yml
+++ b/.github/workflows/feature-branch-chatops.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/feature-branch-chatops.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/feature-branch-chatops.yml@fcbe2ddadb80fa7f643d2a5cb703c31d3e5bbf05 # v0.165.0
     secrets:
       github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/feature-branch.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/feature-branch.yml@fcbe2ddadb80fa7f643d2a5cb703c31d3e5bbf05 # v0.165.0
     secrets:
       github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -15,5 +15,5 @@ permissions: {}
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-branch.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-branch.yml@fcbe2ddadb80fa7f643d2a5cb703c31d3e5bbf05 # v0.165.0
     secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -9,5 +9,5 @@ permissions: {}
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@fcbe2ddadb80fa7f643d2a5cb703c31d3e5bbf05 # v0.165.0
     secrets: inherit

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   scheduled:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/scheduled.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/scheduled.yml@fcbe2ddadb80fa7f643d2a5cb703c31d3e5bbf05 # v0.165.0
     secrets:
       github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
## Info

- Pins all `uses:` references in GitHub Actions workflows to full commit SHAs.

## References

- https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions
